### PR TITLE
fix: remove deprecated Snyk vulnerabilities badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@
   <a href="https://www.npmjs.com/package/mcp-server-nodejs-api-docs"><img src="https://badgen.net/npm/dt/mcp-server-nodejs-api-docs" alt="downloads"/></a>
   <a href="https://github.com/lirantal/mcp-server-nodejs-api-docs/actions/workflows/ci.yml"><img src="https://github.com/lirantal/mcp-server-nodejs-api-docs/actions/workflows/ci.yml/badge.svg" alt="build"/></a>
   <a href="https://app.codecov.io/gh/lirantal/mcp-server-nodejs-api-docs"><img src="https://badgen.net/codecov/c/github/lirantal/mcp-server-nodejs-api-docs" alt="codecov"/></a>
-  <a href="https://snyk.io/test/github/lirantal/mcp-server-nodejs-api-docs"><img src="https://snyk.io/test/github/lirantal/mcp-server-nodejs-api-docs/badge.svg" alt="Known Vulnerabilities"/></a>
   <a href="./SECURITY.md"><img src="https://img.shields.io/badge/Security-Responsible%20Disclosure-yellow.svg" alt="Responsible Disclosure Policy" /></a>
 </p>
 


### PR DESCRIPTION
The Snyk vulnerabilities badge (`snyk.io/test/github/...`) has been deprecated and no longer renders correctly. Removing it from the README so the badge row stays clean.