### PR TITLE
fix: pin CI status badge to default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://www.npmjs.com/package/mcp-server-nodejs-api-docs"><img src="https://badgen.net/npm/v/mcp-server-nodejs-api-docs" alt="npm version"/></a>
   <a href="https://www.npmjs.com/package/mcp-server-nodejs-api-docs"><img src="https://badgen.net/npm/license/mcp-server-nodejs-api-docs" alt="license"/></a>
   <a href="https://www.npmjs.com/package/mcp-server-nodejs-api-docs"><img src="https://badgen.net/npm/dt/mcp-server-nodejs-api-docs" alt="downloads"/></a>
-  <a href="https://github.com/lirantal/mcp-server-nodejs-api-docs/actions/workflows/ci.yml"><img src="https://github.com/lirantal/mcp-server-nodejs-api-docs/actions/workflows/ci.yml/badge.svg" alt="build"/></a>
+  <a href="https://github.com/lirantal/mcp-server-nodejs-api-docs/actions/workflows/ci.yml"><img src="https://github.com/lirantal/mcp-server-nodejs-api-docs/actions/workflows/ci.yml/badge.svg?branch=main" alt="build"/></a>
   <a href="https://app.codecov.io/gh/lirantal/mcp-server-nodejs-api-docs"><img src="https://badgen.net/codecov/c/github/lirantal/mcp-server-nodejs-api-docs" alt="codecov"/></a>
   <a href="./SECURITY.md"><img src="https://img.shields.io/badge/Security-Responsible%20Disclosure-yellow.svg" alt="Responsible Disclosure Policy" /></a>
 </p>


### PR DESCRIPTION
The CI status badge in the README points to the workflow URL without a branch query parameter, which can show the status of any branch (e.g. PR runs) rather than the default branch. Pinning the badge to the repository default branch so it consistently reflects mainline CI.