### PR TITLE
chore: replace deprecated tsconfig baseUrl with paths + types

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,10 +7,17 @@
     "allowJs": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "types": [
+      "node"
+    ],
     "moduleResolution": "NodeNext",
     "module": "NodeNext",
     "target": "ES2022",
-    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "./src/*"
+      ]
+    },
     "noEmit": true,
     "rootDir": "./src",
     "declaration": true,


### PR DESCRIPTION
TypeScript 6 started failing the CI build with `TS5101` because `compilerOptions.baseUrl` is now deprecated and scheduled to stop working in TypeScript 7. This change removes the deprecated setting and migrates the project to an explicit alias-based configuration.

- **Problem**
  - `tsc` fails on `tsconfig.json` due to deprecated `baseUrl`.
  - The repo was not relying on root-based imports today, but the deprecated setting still blocked the build after the TypeScript upgrade.

- **Config migration**
  - remove `compilerOptions.baseUrl`
  - add an explicit alias mapping via `compilerOptions.paths`
  - keep module resolution aligned with the current Node/ESM setup

- **Type resolution**
  - add `types: ["node"]` so Node built-ins continue resolving cleanly under the updated config

- **Result**
  - the project no longer depends on deprecated `baseUrl` behavior
  - future internal imports can use an explicit alias instead of implicit root lookup

```json
{
  "compilerOptions": {
    "types": ["node"],
    "paths": {
      "@/*": ["./src/*"]
    }
  }
}
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CI failures on TypeScript 6 (TS5101) by removing deprecated `compilerOptions.baseUrl` and switching to explicit aliases. Added `paths` with `@/*` -> `./src/*` and `types: ["node"]` to keep Node built-ins resolving under `NodeNext`.

<sup>Written for commit cf9e77ef575d205101f16dc69f58ff97d5e208a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/mcp-server-nodejs-api-docs/pull/124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

